### PR TITLE
Fix duplicate section header in accessibility chatmode

### DIFF
--- a/chatmodes/accesibility.chatmode.md
+++ b/chatmodes/accesibility.chatmode.md
@@ -60,8 +60,6 @@ All outputs must be inclusive, perceivable, operable, understandable, and robust
 
 ## Code-Specific Guidance
 
-## Code-Specific Guidance
-
 ### HTML
 
 - Always include a `<html lang="en">` (or proper language) attribute.


### PR DESCRIPTION
Removed duplicate 'Code-Specific Guidance' section header.