### PR TITLE
feat: improve skill review scores for 5 skills

### DIFF
--- a/plugins/tech-debt-analysis/skills/tech-debt-analysis/SKILL.md
+++ b/plugins/tech-debt-analysis/skills/tech-debt-analysis/SKILL.md
@@ -1,233 +1,137 @@
 ---
 name: tech-debt-analysis
-description: Analyze technical debt in codebases and test suites using evidence-based signals. Produces a structured, prioritized Technical Debt Report with risk assessment, test impact analysis, remediation options, and ROI-aware recommendations.
+description: "Systematically identify, classify, and prioritize technical debt across code, tests, architecture, dependencies, and pipelines. Use when assessing codebase health, diagnosing slow or flaky tests, preparing refactoring roadmaps, or building ROI-aware remediation plans. Produces a structured Technical Debt Report with risk assessment, test impact analysis, and prioritized recommendations."
+argument-hint: "Path to codebase or module, scope (repo/module/test-layer), and known pain points"
+user-invocable: true
 ---
 
-# 🧱 Technical Debt Analysis Skill
+# Technical Debt Analysis
 
-This skill enables an AI agent to **systematically identify, classify, and
-prioritize technical debt** across code, tests, architecture, dependencies,
-and delivery pipelines.
+Use this skill to produce an evidence-based, prioritized technical debt assessment.
+It covers code, test suites, architecture, dependencies, CI/CD pipelines, and documentation — with explicit emphasis on test debt as a first-class concern.
 
----
+## When to Use
 
-## 🎯 When to Use
+- "assess the health of this codebase"
+- "why are our tests slow, flaky, or unreliable?"
+- "prioritize refactoring work with clear ROI"
+- "identify quality risks hiding behind working systems"
+- "prepare input for a technical roadmap or quality initiative"
 
-Use this skill when you need to:
+## Analysis Workflow
 
-- Assess the **health and sustainability** of a codebase
-- Identify **quality risks hidden behind “working” systems**
-- Understand **why testing is slow, flaky, or ineffective**
-- Prioritize refactoring work with **clear impact and ROI**
-- Prepare input for **technical roadmap or quality initiatives**
-- Decide **what technical debt to fix vs consciously accept**
+Follow the phases in order. Never skip discovery or evidence collection.
 
----
+### Phase 0: Context and scope
 
-## 🧭 Operational Workflow
+Before analysis, establish:
 
-The agent must follow the phases below **in order**.
-Skipping discovery or evidence collection is not allowed.
-
----
-
-### Phase 0: Context & Strategy Selection (Mandatory)
-
-Before analysis, clarify the context.
-
-Ask (or infer safely if explicitly stated):
-
-- System type: Frontend / Backend / API / Test Automation / Platform
-- Current pain points: bugs, regressions, slow CI, flaky tests, low confidence
-- Scope of analysis: whole repo / module / test layer only
-- Constraints: time, legacy code, “no refactors”, compliance
-- Goal: awareness / prioritization / remediation planning
+- **system type**: frontend, backend, API, test automation, or platform
+- **pain points**: bugs, regressions, slow CI, flaky tests, low confidence
+- **scope**: whole repo, specific module, or test layer only
+- **constraints**: time, legacy code, compliance, "no refactors" policy
+- **goal**: awareness, prioritization, or remediation planning
 
 If information is missing, mark as `TBD` and list assumptions explicitly.
 
----
+### Phase 1: Debt signal collection
 
-### Phase 1: Debt Signal Collection (Evidence First)
+Identify observable signals, not conclusions. Sources to check:
 
-Identify **observable signals**, not conclusions.
+- **Code structure** — complexity, duplication, coupling
+- **Test behavior** — flakiness, runtime, coverage gaps, weak assertions
+- **CI/CD signals** — build time, retry patterns, failure rates
+- **Dependencies** — age, CVEs, maintenance status
+- **Change history** — hotspots, frequent fixes
+- **Documentation** — missing ADRs, tribal knowledge
 
-Possible signal sources:
-- Code structure (complexity, duplication, coupling)
-- Test behavior (flakiness, runtime, coverage gaps)
-- CI/CD signals (build time, retry patterns, failure rates)
-- Dependency metadata (age, CVEs, maintenance status)
-- Change history (hotspots, frequent fixes)
-- Documentation gaps (missing ADRs, tribal knowledge)
+If no signal or evidence exists, do not report debt — log it as an assumption or unknown.
 
-> If no signal or evidence exists, do **not** report debt - log it as an assumption or unknown.
+### Phase 2: Debt classification
 
----
+Every debt item must have one primary category from this fixed taxonomy:
 
-### Phase 2: Debt Classification (Use a Fixed Taxonomy)
+- **Code Debt** — smells, complexity, duplication
+- **Test Debt** — missing tests, flaky tests, slow feedback, weak assertions
+- **Architecture Debt** — tight coupling, layering violations, unclear boundaries
+- **Dependency Debt** — outdated, risky, or abandoned libraries
+- **Process Debt** — slow CI, manual steps, poor feedback loops
+- **Documentation Debt** — missing ADRs, unclear ownership, tribal knowledge
 
-Every debt item must be classified into **one primary category**:
+An optional secondary category may be added if justified.
 
-- **Code Debt** – smells, complexity, duplication
-- **Test Debt** – missing tests, flaky tests, slow feedback, weak assertions
-- **Architecture Debt** – tight coupling, layering violations, unclear boundaries
-- **Dependency Debt** – outdated, risky, abandoned libraries
-- **Process Debt** – slow CI, manual steps, poor feedback loops
-- **Documentation Debt** – missing ADRs, unclear ownership, tribal knowledge
+### Phase 3: Risk and impact assessment
 
-Optional secondary category may be added if justified.
+Evaluate each debt item on four dimensions using Low / Medium / High with justification:
 
----
+- **Impact** — what breaks or slows if this remains?
+- **Likelihood** — how often does it cause issues?
+- **Quality risk** — bug escape probability, regression risk, confidence loss
+- **Test impact** — does it reduce testability or reliability?
 
-### Phase 3: Risk & Impact Assessment
+## Output Schema
 
-Each debt item must be evaluated using **risk-based thinking**:
+Produce a markdown file named `TECHNICAL_DEBT_REPORT.md` with these sections.
 
-- **Impact**: What breaks or slows if this remains?
-- **Likelihood**: How often does it cause issues?
-- **Quality Risk**: Bug escape, regression risk, confidence loss
-- **Test Impact**: Does it reduce testability or reliability?
+### Metadata
 
-Use simple scales (Low / Medium / High) but justify each rating.
+Version, status (Draft/Review/Approved), scope analyzed, owner, date, and assumptions.
 
----
+### Executive Summary
 
-## 🧾 Output Schema (Strict)
+Overall debt health (Low/Medium/High), top 5 debt drivers by risk, major quality or testing risks, and recommended next actions.
 
-The final output must be a markdown file named: TECHNICAL_DEBT_REPORT.md and follow the structure below.
+### Debt Inventory
 
----
-
-### 0️⃣ Document Metadata
-
-- Version: `0.x`
-- Status: Draft / Review / Approved
-- Scope Analyzed:
-- Owner:
-- Date:
-- Assumptions:
-
----
-
-### 1️⃣ Executive Summary
-
-- Overall technical debt health: Low / Medium / High
-- Top 5 debt drivers (by risk)
-- Major quality or testing risks identified
-- Recommended next actions (short list)
-
----
-
-### 2️⃣ Debt Inventory (Atomic Records)
-
-Each debt item must be listed as an **atomic record**.
+Each debt item as an atomic record:
 
 ```
-Debt ID:
-Category:
-Location (files/modules/tests):
-Description:
-Observed Evidence:
-Impact:
-Likelihood:
-Quality/Test Impact:
-Fix Options:
-Estimated Effort (S/M/L):
-Recommendation:
+Debt ID: TD-042
+Category: Test Debt
+Location: tests/integration/payments/
+Description: Payment integration tests use hardcoded sleep waits instead of polling
+Observed Evidence: 14 instances of sleep(5000) in 8 test files; CI retry rate 23%
+Impact: High — flaky failures block releases, erode trust in test suite
+Likelihood: High — triggers on every CI run under load
+Quality/Test Impact: High — masks real regressions behind noise
+Fix Options: Replace sleeps with explicit wait conditions; extract shared polling utility
+Estimated Effort: M
+Recommendation: Fix Soon — highest ROI flakiness reduction
 ```
 
-Rules:
-- No evidence → no debt item
-- Avoid generic wording (“code is messy”)
-- Be precise and scoped
+Rules: no evidence means no debt item; avoid vague wording ("code is messy"); be precise and scoped.
 
----
+### Test and Quality Risk Summary
 
-### 3️⃣ Test & Quality Risk Summary
+Summarize how debt affects bug escape probability, regression risk, coverage effectiveness, test stability, execution time, and release confidence. Highlight test debt explicitly even when code debt dominates.
 
-Summarize how technical debt affects:
+### Prioritization Matrix
 
-- Bug escape probability
-- Regression risk
-- Test coverage effectiveness
-- Test stability and execution time
-- Confidence in releases
+Group items into three tiers:
 
-Highlight **test debt explicitly**, even if code debt dominates.
+- **Fix Now** — high risk, high impact, blocking quality
+- **Fix Soon** — important but not currently blocking
+- **Accept for Now** — conscious debt with documented rationale
 
----
+Explain why some debt should not be fixed yet.
 
-### 4️⃣ Prioritization & Decision Matrix
+### Remediation Roadmap
 
-Group debt items into:
+For top-priority items: suggested steps, safer refactoring strategies (test-first when possible), dependencies or prerequisites, and validation strategy (how you confirm improvement). Avoid big-bang rewrites unless explicitly justified.
 
-- **Fix Now** – high risk, high impact
-- **Fix Soon** – important but not blocking
-- **Accept for Now** – conscious debt with rationale
+### Change Impact and ROI
 
-Explain *why* some debt should **not** be fixed yet.
+For major fixes: what becomes easier to test, what risks are reduced, what developer or QA friction is removed. This section supports stakeholder buy-in.
 
----
+## Quality Rules
 
-### 5️⃣ Remediation Roadmap (Incremental)
+- **Evidence required** — base every finding on observable signals; list assumptions explicitly
+- **Test debt is first-class** — always analyze test impact even when code debt dominates
+- **Incremental remediation** — prefer test-safe, incremental fixes over rewrites
+- **Acknowledge uncertainty** — say when context is missing rather than guessing
+- **No hallucinated intent** — do not invent design decisions or project history
+- **Proportionate severity** — do not treat all debt as equally urgent; cosmetic issues are not blockers
 
-For top-priority items:
+## Self-Check
 
-- Suggested remediation steps
-- Safer refactoring strategies (test-first if needed)
-- Dependencies or prerequisites
-- Validation strategy (how we know it improved)
-
-Avoid “big bang” rewrites unless explicitly justified.
-
----
-
-### 6️⃣ Change Impact & ROI Notes
-
-For major fixes, describe:
-- What becomes easier to test
-- What risks are reduced
-- What developer or QA friction is removed
-
-This section is critical for stakeholder buy-in.
-
----
-
-## 🧠 AI Safety & Quality Rules
-
-### DO
-- Base findings on observable evidence
-- Explicitly list assumptions
-- Treat test debt as first-class technical debt
-- Prefer incremental, test-safe remediation
-- Acknowledge uncertainty
-
-### DON’T
-- Hallucinate intent or design decisions
-- Recommend refactors without test safety
-- Over-optimize cosmetic issues
-- Treat all debt as equally urgent
-
----
-
-## ✅ AI Self-Review Checklist
-
-Before finalizing:
-
-- [ ] Every debt item has evidence
-- [ ] Debt categories are used consistently
-- [ ] Test impact is explicitly analyzed
-- [ ] Risks are justified, not guessed
-- [ ] “Acceptable debt” is documented
-- [ ] Recommendations are realistic and incremental
-
----
-
-## 🎯 Outcome
-
-When applied correctly, this skill produces a **credible, actionable, and
-architecturally sound technical debt assessment** that:
-
-- improves system quality,
-- strengthens test effectiveness,
-- reduces long-term risk,
-- and supports informed decision-making.
+Before finalizing, verify: every debt item has evidence, categories are consistent, test impact is explicitly analyzed, risk ratings are justified, acceptable debt is documented, and recommendations are realistic and incremental.

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,89 +1,106 @@
 ---
 name: code-review
-description: Assists users with code review, providing feedback on code quality, best practices, and potential improvements. Use always when user asks for code review or when there are code changes to review, providing feedback on code quality, structure, readability, maintainability, and adherence to coding standards. This skill provides information on best practices for code review, including how to identify issues, suggest improvements, and communicate feedback effectively.
+description: "Reviews code changes and pull requests for correctness, security, performance, and maintainability. Use when a PR diff is ready, a user asks for feedback on code quality, or a change needs sign-off before merge."
+argument-hint: "File paths, PR URL, or diff context to review"
+user-invocable: true
 ---
 
-## Overview
+# Code Review
 
-The `code-review` skill helps reviewers apply consistent, high-quality assessments across code changes when reviewing code. It focuses on key principles of code quality:
-
-- Safety (avoid incorrect assumptions; call out uncertain areas)
-- Clarity (structuring comments in positive and actionable form)
-- Coverage (address correctness, tests, security, performance, readability)
+Use this skill when code changes need a structured, consistent review before they land.
+It produces categorized findings with actionable suggestions so the author can iterate quickly.
 
 ## When to Use
 
-1. User asks for code review.
-2. Pull request diff is ready and you must provide code review comments.
-3. You are auditing a code change for architecture, compliance, or release readiness.
-4. You need a checklist for manual or automated review before approving.
+Use this skill when the user asks for things like:
 
-## Skill Behavior
+- "review this pull request"
+- "check these changes before I merge"
+- "audit this diff for security and performance"
+- "give me feedback on code quality"
+- "what could go wrong with this change?"
 
-- Start with a summary: what is changing, why, and whether the implementation is aligned with goals.
-- Categorize findings:
-  - ✅ Strengths / wins
-  - ⚠️ Concerns / risks
-  - 🛠️ Suggestions / improvements
-- Provide `short-term` fix guidance plus `long-term` design thoughts.
-- Flag any missing tests, docs, or standards violations.
-- Respect context: mention the module/file/function names (not generic: "the code").
+Typical scenarios:
 
-## Best-practice Review Checklist
+- reviewing a PR diff before approval
+- auditing a feature branch for release readiness
+- checking a refactor for regressions or missed edge cases
+- validating that tests, docs, and standards are covered
 
-1. **Correctness**
-   - Does the code do what the ticket/PR describes?
-   - Are edge cases handled (null, errors, concurrency, format) ?
-   - Any regression risk from changed behavior?
+## Review Principles
 
-2. **Maintainability**
-   - Is the implementation easy to read and reason about?
-   - Are abstractions and naming appropriate?
-   - Any repeated logic that should be refactored?
+- **Specific over generic** — reference exact file, function, and line; never say "the code."
+- **Actionable over critical** — every concern includes a concrete fix or next step.
+- **Teammate tone** — use "Consider", "Could", "Worth checking" instead of directives.
+- **Context-aware** — weigh findings against the goal of the change (bug fix vs. feature vs. refactor).
 
-3. **Testing**
-   - Are unit and integration tests present and relevant?
-   - Do tests cover both normal and boundary cases?
-   - Are tests deterministic and fast?
+## Workflow
 
-4. **Security & Privacy**
-   - Are user inputs validated/escaped and untrusted data treated carefully?
-   - Any secrets in code, logs, or config?
-   - Does the change introduce new permissions, cross-origin, or auth gaps?
+### Phase 0: Scope the review
 
-5. **Performance**
-   - Any obvious O(N^2) loops or hot-path allocations?
-   - Are caching and batching used when appropriate?
-   - For network I/O, is retry/backoff and timeout handling present?
+Before reading code, establish:
 
-6. **Style/Convention**
-   - Follow team linting rules and style guide (naming, indent, line length).
-   - Approve clean diff with minimal noise in formatting.
+- what the change is meant to accomplish (ticket, PR description, commit messages)
+- which files and modules are affected
+- the project's language, framework, and relevant style conventions
+- any areas the author flagged for extra attention
 
-7. **Documentation**
-   - Public APIs should be documented.
-   - Migration notes, config docs, and README changes included if needed.
+### Phase 1: Systematic review pass
 
-## Prompt Pattern
+Walk through the diff against this checklist, noting findings as you go:
 
-Use this template for your code review request:
+- **Correctness** — does the code match the stated intent? Are edge cases (null, empty, concurrent, malformed input) handled?
+- **Security** — are inputs validated and escaped? Any secrets, new permissions, or auth gaps?
+- **Performance** — obvious quadratic loops, hot-path allocations, missing timeouts or retry/backoff?
+- **Testing** — are unit and integration tests present, deterministic, and covering boundary cases?
+- **Maintainability** — is naming clear, abstraction appropriate, duplication minimal?
+- **Style and docs** — does the diff follow project linting rules? Are public APIs documented and migration notes included?
 
-```
-You are a senior code reviewer.
-Project context: <technology stack and repository>
-Changed files: <list or path prefix>
-Key goals: <bug fix, feature, refactor, perf>
-Specific concerns: <optional>
-Please provide:
-- High-level summary
-- Risk assessment
-- Specific line comments / suggestions
-- Example improvement snippets
-```
+### Phase 2: Categorize and present findings
 
-## Output Style
+Organize findings into three groups:
 
-- Keep each comment concise (1-2 sentences plus the issue).
-- Use bullet points for multiple issues.
-- Use neutral, teammate-first language (`Consider`, `Could`, `Would` instead of `You`).
-- Include a final recommendation state: `approve`, `request changes`, or `comment`.
+- **Strengths** — what works well and should be preserved
+- **Concerns** — issues that should be addressed before merge, with suggested fixes
+- **Suggestions** — optional improvements for readability, performance, or long-term design
+
+For each concern or suggestion, include the file path, a brief explanation, and a concrete fix.
+
+#### Example finding
+
+> **Concern — missing null check in `src/api/users.ts:42`**
+>
+> `getUser` can return `null` when the ID is not found, but the caller dereferences immediately.
+>
+> ```ts
+> // before
+> const user = await getUser(id);
+> return user.email; // throws if user is null
+>
+> // after
+> const user = await getUser(id);
+> if (!user) {
+>   throw new NotFoundError(`User ${id} not found`);
+> }
+> return user.email;
+> ```
+
+### Phase 3: Verdict
+
+Close the review with one of:
+
+- **Approve** — no blocking issues; optional suggestions only
+- **Request changes** — one or more concerns must be resolved before merge
+- **Comment** — informational feedback; no approval or block implied
+
+Include a one-sentence summary of the overall assessment and any short-term vs. long-term recommendations.
+
+## Definition of Done
+
+A review using this skill is complete when:
+
+- every changed file has been examined against the checklist
+- findings are categorized, specific, and actionable
+- at least one strength is called out alongside any concerns
+- a clear verdict is stated with rationale
+- the tone is constructive and teammate-first throughout

--- a/skills/creating-prompts/SKILL.md
+++ b/skills/creating-prompts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-prompts
-description: "Creates GitHub Copilot prompt files (`.prompt.md`) for VS Code. Use when building reusable workflow starters that route work to the right agent, collect the right inputs, and ship with install-ready templates, examples, and validation guidance."
+description: "Creates GitHub Copilot prompt files (`.prompt.md`) for VS Code. Use when the user asks to create, improve, or templatize a `.prompt.md` file — e.g. building a reusable slash-command, routing a task to a specific agent, standardizing repeated workflows, or fixing a vague prompt. Ships install-ready templates, examples, and validation guidance."
 argument-hint: "Prompt goal, target agent, required inputs, and desired output"
 user-invocable: true
 ---
@@ -16,16 +16,13 @@ Use this skill when the user asks for things like:
 
 - "create a prompt file for this workflow"
 - "turn this repeated request into a `.prompt.md`"
+- "make a slash-command that runs this analysis"
 - "route this task to the right agent with guided input"
 - "fix a prompt that is too vague or too generic"
+- "templatize this workflow so the team can reuse it"
 - "add a reusable prompt example for the team"
 
-Typical scenarios:
-
-- creating a focused slash-command entrypoint
-- standardizing a frequent analysis or generation workflow
-- capturing required inputs and outputs for a specialized task
-- improving prompt usability for a repository or public collection
+Typical scenarios: creating a slash-command entrypoint, standardizing a frequent workflow, capturing required inputs/outputs for a specialized task, or improving prompt discoverability for a repo or public collection.
 
 ## Outcome Standard
 
@@ -63,14 +60,7 @@ Clarify or infer:
 
 ### Phase 2: Draft the frontmatter
 
-Choose the smallest useful set of fields:
-
-- `name` for a readable menu label when needed
-- `agent` to route the workflow intentionally
-- `description` to make the prompt discoverable
-- `model` when a model choice materially matters
-- `argument-hint` when the user needs help providing the right context
-- `tools` only when the prompt truly needs to override defaults
+Choose the smallest useful set of fields: `name` (menu label), `agent` (routing), `description` (discoverability), `model` (only when it materially matters), `argument-hint` (guides user input), and `tools` (only when overriding defaults is required).
 
 ### Phase 3: Write the prompt body
 
@@ -86,6 +76,25 @@ A good prompt body should usually include:
 - a numbered workflow
 - output expectations or completion criteria
 - constraints when the workflow should stay within tight bounds
+
+**Minimal example** of a complete `.prompt.md` file:
+
+```markdown
+---
+name: Summarize PR
+agent: code-review
+description: "Summarize a pull request's changes and flag risks"
+argument-hint: "PR number or URL"
+---
+
+Summarize the pull request provided by the user.
+
+1. List changed files grouped by area (API, UI, tests, config).
+2. Highlight breaking changes or risk areas.
+3. Output a short summary (under 200 words) plus a risk rating (low / medium / high).
+```
+
+See `./resources/prompt.example.prompt.md` for a fuller worked example.
 
 ### Phase 4: Package the reference bundle
 

--- a/skills/designing-test-data/SKILL.md
+++ b/skills/designing-test-data/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: designing-test-data
-description: 'Designs realistic, boundary-heavy, and role-aware test data packs for manual and automated testing. Use when a feature needs deliberate inputs and fixtures before execution, when edge-case values keep being improvised, or when automation needs stable example data with setup notes.'
+description: 'Generates boundary values, creates role-based user fixtures, and produces grouped test data catalogs with setup and cleanup scripts. Use when a feature needs deliberate test inputs before execution, when edge-case or mock data is being improvised instead of planned, or when automation requires stable sample data, dummy records, or seed fixtures with environment notes.'
 argument-hint: 'Entities, fields, constraints, roles, state combinations, and whether data is for manual or automated use'
 user-invocable: true
 ---
@@ -12,11 +12,11 @@ It helps turn vague "use some sample data" habits into deliberate datasets that 
 
 ## When to Use
 
-- prepare test data before manual execution starts
-- create stable fixtures for automation work
-- design edge-case inputs from field constraints
-- generate role-aware or state-aware data combinations
-- replace improvised sample values with a reusable data catalog
+- Prepare deliberate test data before manual execution starts
+- Build stable fixtures and seed data for automation suites
+- Derive edge-case inputs from field constraints and business rules
+- Generate role-aware or state-aware data combinations across workflows
+- Replace improvised sample values with a reusable, grouped data catalog
 
 ## Data Design Rules
 
@@ -25,6 +25,7 @@ It helps turn vague "use some sample data" habits into deliberate datasets that 
 - **Synthetic first** - use safe, non-sensitive values unless the user explicitly provides approved test data.
 - **Dependencies must be visible** - if a dataset requires setup, state it clearly.
 - **Time and state matter** - dates, expirations, roles, and lifecycle states often create the real edge cases.
+- **Every set needs a reason** - never dump data tables without explaining why each group exists and what it exercises.
 
 ## Workflow
 
@@ -64,16 +65,41 @@ Generate values across these buckets where relevant:
 - **Temporal data** - past, future, leap day, expiry edge, timezone-sensitive values
 - **Stress or awkward data** - long strings, Unicode, duplicate keys, near-collision values
 
+**Example — User Registration data pack (excerpt):**
+
+| # | Username | Email | Age | Role | Purpose |
+|---|----------|-------|-----|------|---------|
+| 1 | `jane_doe` | `jane@example.com` | 25 | user | Typical valid record |
+| 2 | `ab` | `a@b.co` | 18 | user | Boundary — minimum length and minimum age |
+| 3 | `""` | `not-an-email` | -1 | guest | Invalid — empty name, bad format, negative age |
+| 4 | `admin_root` | `admin@example.com` | 65 | admin | Role escalation + upper-age boundary |
+
 ### Phase 3: Package the dataset
 
-Use `./resources/test-data-catalog-template.md` when possible.
+Use `./resources/test-data-catalog-template.md` for full formatting. Minimal catalog structure:
 
-The output should make clear:
+```markdown
+## Scope
+- Feature / flow: [target]
+- Intended use: manual / automation / both
 
-- what the record is for
-- how to use it
-- any setup dependencies
-- whether it is better suited for manual or automated use
+## Data Sets
+| ID | Entity | Category | Example values | Purpose | Setup |
+|----|--------|----------|---------------|---------|-------|
+| TD-001 | User | valid | standard active user | baseline | seed account |
+| TD-002 | User | boundary | max-length name, empty optional | validation edges | same role |
+
+## Role and State Combinations
+| ID | Role | State | Why it matters |
+|----|------|-------|----------------|
+| RSC-001 | guest | new session | public path coverage |
+
+## Notes
+- Cleanup: [reset steps]
+- Masking: [safe-data reminder]
+```
+
+Each record must make clear what it is for, how to use it, any setup dependencies, and whether it suits manual or automated use.
 
 ### Phase 4: Add handling notes
 
@@ -83,14 +109,6 @@ Before finishing, call out:
 - cleanup expectations
 - masking or privacy concerns
 - values that should never be used outside safe test environments
-
-## Common Failure Modes
-
-- only generating happy-path data
-- ignoring entity relationships or setup dependencies
-- using realistic-looking but sensitive data carelessly
-- forgetting state or role permutations
-- writing data tables with no explanation of why each set exists
 
 ## Resource Map
 

--- a/skills/prd-generator/SKILL.md
+++ b/skills/prd-generator/SKILL.md
@@ -1,302 +1,132 @@
 ---
 name: prd-generator
-description:  Generate production-ready Product Requirements Documents (PRDs) for software systems and AI-powered features. The skill ensures clear problem framing, measurable outcomes, scoped functionality, testable requirements, technical feasibility, risk awareness, and stakeholder alignment.
+description: 'Generates production-ready Product Requirements Documents for software systems and AI-powered features. Covers problem framing, measurable outcomes, scoped functionality, testable requirements, technical feasibility, risk awareness, and stakeholder alignment. Use when writing a PRD, defining requirements for a feature, turning a vague idea into a spec, planning an AI/ML product, or aligning stakeholders before development.'
+argument-hint: 'Product idea, feature brief, problem statement, stakeholder context, constraints, and any existing notes or prior PRDs'
+user-invocable: true
 ---
 
-# 📄 Product Requirements Document (PRD) Skill
+# Product Requirements Document (PRD) Generator
 
-This skill enables an AI agent to produce **high-quality, professional PRDs**
-that serve as a **single source of truth** for product, design, engineering,
-QA, and leadership teams.
+Use this skill to produce high-quality, professional PRDs that serve as a single source of truth for product, design, engineering, QA, and leadership teams.
+The PRD balances business goals, user needs, and technical execution for both traditional software and AI-driven products.
 
-The PRD balances **business goals**, **user needs**, and **technical execution**,
-and supports both traditional software systems and AI-driven products.
+## When to Use
 
----
+- write a PRD, define requirements, or plan a feature
+- turn a vague idea into an implementation-ready specification
+- align multiple stakeholders before development begins
+- document requirements for AI/ML-enabled systems
+- create a versioned reference document that evolves with the product
 
-## 🧠 What This Skill Does
+## Operating Principles
 
-When invoked, this skill:
+- **Never generate immediately** - always reduce uncertainty through discovery before drafting.
+- **Measurable over subjective** - replace "fast" with "P95 latency <= 200ms"; replace "easy to use" with a Lighthouse score.
+- **Testable by design** - every requirement states how it will be validated, what can be automated, and what signals failure.
+- **Assumptions stay visible** - unvalidated conditions are listed explicitly, never buried.
+- **Living document** - track versions, incorporate feedback, revisit assumptions as information emerges.
+- **Adapt depth to risk** - MVP, growth, and scale products need different rigor levels.
 
-- Elicits missing context through structured discovery
-- Translates ambiguous ideas into clear, actionable requirements
-- Produces a complete, testable, and measurable PRD
-- Makes assumptions and risks explicit
-- Adapts depth and rigor to product maturity and risk
-- Treats the PRD as a **living, versioned artifact**
+## Workflow
 
----
+### Phase 0: Strategy selection
 
-## 🎯 When to Use
+Classify the PRD before discovery to calibrate structure and rigor:
 
-Use this skill when the user wants to:
+- **Product stage**: MVP / Growth / Scale
+- **Risk level**: Low / Medium / High
+- **AI criticality**: None / Supporting / Core
+- **Primary audience**: Engineering / Product / Exec / External
 
-- "Write a PRD", "define requirements", or "plan a feature"
-- Turn a vague idea into an implementation-ready specification
-- Align multiple stakeholders before development
-- Document requirements for **AI / ML-enabled systems**
-- Create a reference document that evolves with the product
+The classification determines depth, detail, and validation rigor throughout.
 
----
+### Phase 1: Structured discovery
 
-## 🧩 Operational Workflow
+Ask clarifying questions before drafting. Cover at minimum:
 
-A PRD **must never be generated immediately** from a single prompt.
-The agent must first reduce uncertainty and align expectations.
+1. **Problem and context** - what problem, why now
+2. **Users and value** - primary users, desired outcomes
+3. **Success measurement** - KPIs, definition of "good"
+4. **Constraints** - deadlines, budget, tech stack, compliance
+5. **Stakeholders** - who needs alignment or approval
 
----
+Do not proceed until at least three major uncertainties are resolved.
 
-### Phase 0: PRD Strategy Selection
+### Phase 2: Draft the PRD
 
-Before discovery, classify the PRD to adapt structure and rigor:
+Follow the mandatory output structure below. Adapt section depth to the strategy classification from Phase 0.
 
-- **Product Stage**: MVP / Growth / Scale
-- **Risk Level**: Low / Medium / High
-- **AI Criticality**: None / Supporting / Core
-- **Primary Audience**: Engineering / Product / Exec / External
+### Phase 3: Validate and iterate
 
-> The chosen strategy determines depth, level of detail, and validation rigor.
+Run the self-review checklist before finalizing. Incorporate feedback from product, engineering, QA, and stakeholders. Re-check assumptions as new information surfaces.
 
----
+## PRD Structure (Mandatory Output Schema)
 
-### Phase 1: Discovery - Structured Elicitation
+1. **Executive Summary** - problem statement (1-3 sentences), proposed solution (1-3 sentences), 3-5 measurable success KPIs
+2. **Context and Strategic Alignment** - business context, strategic goals supported, relevant constraints or market considerations
+3. **User Experience and Functional Scope** - personas with goals and pain points, user scenarios/flows, user stories with acceptance criteria, explicit non-goals
+4. **Success Metrics and Release Criteria** - business KPIs (adoption, retention, revenue), technical KPIs (latency, throughput, error rates), quality KPIs (availability, reliability), release readiness checklist
+5. **Technical Requirements and Constraints** - high-level architecture overview, component breakdown (services, APIs, data stores), non-functional requirements (performance, security, scalability, compliance), integration points and dependencies
+6. **AI/ML Requirements** (include only when AI is core or supporting) - models/tools/services, input/output specs, evaluation strategy, monitoring and drift detection, fallback behavior, data privacy and safety
+7. **Risks, Assumptions, and Dependencies** - risks with impact, likelihood, and mitigation; unvalidated assumptions; team/system/vendor dependencies
+8. **Roadmap and Phased Delivery** - table with Phase, Goals, Dependencies, and Exit Criteria for each increment (MVP, v1.1, Future)
 
-The agent must ask **clarifying questions** before drafting.
+## Self-Review Checklist
 
-Use a structured approach (Who / What / Why / When / How):
+Before finalizing, verify:
 
-1. **Problem & Context**
-   - What problem are we solving?
-   - Why does it matter now?
-2. **Users & Value**
-   - Who are the primary users?
-   - What outcome do they care about?
-3. **Success & Measurement**
-   - How will success be measured?
-   - What does "good" look like?
-4. **Constraints**
-   - Deadlines, budget, tech stack, compliance?
-5. **Stakeholders**
-   - Who needs alignment or approval?
+- all success metrics are measurable
+- assumptions are explicitly listed
+- non-goals are clearly stated
+- risks include mitigation strategies
+- every major requirement is testable
+- no undefined terms remain
+- AI systems define offline evaluation and runtime monitoring
 
-> Do not proceed until **at least 3 major uncertainties** are resolved.
+## Common Failure Modes
 
----
+- generating a PRD from a single prompt without discovery
+- using subjective language instead of measurable criteria
+- omitting non-goals and letting scope creep in
+- treating AI requirements as an afterthought
+- listing risks without mitigation strategies
+- skipping stakeholder alignment before finalizing
 
-## 🧾 PRD Structure - Mandatory Output Schema
-
-The PRD output **must follow this exact structure and order**.
-
----
-
-### 1️⃣ Executive Summary
-
-**Purpose**: Provide a concise, decision-friendly overview.
-
-- **Problem Statement**  
-  1–3 sentences describing the core pain or opportunity.
-- **Proposed Solution**  
-  1–3 sentences describing the approach (not implementation details).
-- **Success Criteria**  
-  3–5 measurable KPIs (business, technical, or quality).
-
----
-
-### 2️⃣ Context & Strategic Alignment
-
-**Purpose**: Explain why this work matters.
-
-- Business or product context
-- Strategic goals supported by this initiative
-- Relevant constraints or market considerations
-
----
-
-### 3️⃣ User Experience & Functional Scope
-
-**Purpose**: Anchor requirements in user value.
-
-- **User Personas**  
-  Primary personas with goals and pain points.
-- **User Scenarios / Flows**  
-  High-level description of how users interact with the system.
-- **User Stories**  
-  `As a [persona], I want to [action] so that [benefit].`
-- **Acceptance Criteria**  
-  Clear, testable "done" conditions per story.
-- **Out of Scope / Non-Goals**  
-  Explicit exclusions to prevent scope creep.
-
----
-
-### 4️⃣ Success Metrics & Release Criteria
-
-**Purpose**: Define outcomes and readiness.
-
-- **Business KPIs**  
-  Adoption, retention, revenue, efficiency.
-- **Technical KPIs**  
-  Latency, throughput, error rates.
-- **Quality KPIs**  
-  Availability, reliability, correctness.
-- **Release Readiness Checklist**  
-  Conditions required for MVP and subsequent releases.
-
----
-
-### 5️⃣ Technical Requirements & Constraints
-
-**Purpose**: Enable engineering execution.
-
-- **High-Level Architecture Overview**  
-  Text or ASCII-based description of components and data flow.
-- **Component Breakdown**  
-  Services, APIs, data stores, integrations.
-- **Non-Functional Requirements**  
-  Performance, security, scalability, privacy, compliance.
-- **Integration Points & Dependencies**  
-  External systems, internal services, third parties.
-
----
-
-### 6️⃣ AI / ML Requirements (If Applicable)
-
-Include **only if AI is a core or supporting capability**.
-
-- Models, tools, or services used
-- Input and output specifications
-- Evaluation and quality measurement strategy
-- Monitoring, drift detection, and fallback behavior
-- Data privacy and safety considerations
-
----
-
-### 7️⃣ Risks, Assumptions & Dependencies
-
-**Purpose**: Surface uncertainty explicitly.
-
-- **Risks**
-  - Description
-  - Impact
-  - Likelihood
-  - Mitigation strategy
-- **Assumptions**
-  - Unvalidated conditions treated as true
-- **Dependencies**
-  - Teams, systems, vendors, or approvals
-
----
-
-### 8️⃣ Roadmap & Phased Delivery
-
-Break delivery into incremental phases:
-
-| Phase | Goals | Dependencies | Exit Criteria |
-|------|------|-------------|---------------|
-| MVP  | ... | ... | ... |
-| v1.1 | ... | ... | ... |
-| Future | ... | ... | ... |
-
----
-
-## 📌 PRD Quality Standards
-
-### Requirements Must Be Measurable
-
-Avoid subjective language.
-
-**Bad**
-- "Fast"
-- "Easy to use"
-- "High quality"
-
-**Good**
-- "P95 latency ≤ 200ms for 10k records"
-- "100% Lighthouse accessibility score"
-- "≥90% precision on benchmark queries"
-
----
-
-## 🧪 Testability by Design
-
-Every major requirement must indicate:
-
-- How it will be validated
-- What can be automated
-- What signals indicate failure
-
-AI systems must define **offline evaluation** and **runtime monitoring**.
-
----
-
-## 🔁 Iteration & Collaboration Rules
-
-- Treat the PRD as a **living document**
-- Track versions and changes
-- Incorporate feedback from product, engineering, QA, and stakeholders
-- Revisit assumptions as new information emerges
-
----
-
-## 🧠 AI Self-Review Checklist
-
-Before finalizing, the agent must verify:
-
-- [ ] All success metrics are measurable
-- [ ] Assumptions are explicitly listed
-- [ ] Non-goals are clearly stated
-- [ ] Risks include mitigation strategies
-- [ ] Requirements are testable
-- [ ] No undefined terms remain
-
----
-
-## 🧪 Example Snippet (Intelligent Search System)
+## Example Snippet (AI-Powered Code Search)
 
 ```
-### Document Metadata
+Version: 0.1 | Status: Draft | Owner: TBD
 
-- Version: 0.1
-- Status: Draft
-- Last Updated: YYYY-MM-DD
-- Owner: TBD
-
-### Change Log
-
-v0.1 – Initial draft
-
-### 1. Executive Summary
+1. Executive Summary
 Problem: Developers struggle to find code snippets in large repos.
 Solution: AI-enabled code search with natural language interface.
-Success KPIs:
-- ≤200ms P95 query latency
-- ≥90% relevance on benchmark queries
-- 30% increase in daily active users
+KPIs: P95 latency <= 200ms, >= 90% relevance on benchmark, 30% DAU increase.
 
-### 2. User Stories
+2. User Stories
 As a developer, I want to ask plain-English questions so I find code faster.
-Acceptance:
-- Multi-turn refinement
-- Code snippets with citations
+Acceptance: multi-turn refinement, code snippets with citations.
 
-### 4. Technical Specs
-Architecture:
-- NLP Service -> Vector DB -> Search API
-Performance:
-- Search P95 ≤ 200ms under 10k docs
-...
+3. Technical Specs
+Architecture: NLP Service -> Vector DB -> Search API
+Performance: search P95 <= 200ms under 10k docs.
 
-### Risks
-- Model drift
-- Cost of embeddings
-...
-
-### PRD Quality Review (AI Self-Check)
-
-- [ ] All success metrics are measurable
-- [ ] No undefined technical terms
-- [ ] Assumptions explicitly listed
-- [ ] Non-goals clearly stated
-- [ ] Risks have mitigation strategies
-
+4. Risks
+- Model drift: monitor weekly, retrain on threshold breach.
+- Embedding cost: budget cap with fallback to keyword search.
 ```
+
+## Related Skills
+
+- `requirements-test-coverage-mapper` - when the PRD needs traceability to test coverage
+- `designing-functional-tests` - when requirements are ready to expand into test scenarios
+- `verifying-acceptance-criteria` - when checking whether delivered features meet PRD acceptance criteria
+
+## Definition of Done
+
+This skill is complete when:
+
+- discovery resolved at least three major uncertainties
+- the PRD follows the mandatory output structure
+- all success metrics are measurable and testable
+- risks, assumptions, and non-goals are explicit
+- the document is ready for stakeholder review and engineering handoff


### PR DESCRIPTION
Hey @jaktestowac 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| prd-generator | 47% | 90% | +43% |
| tech-debt-analysis (plugin) | 61% | 90% | +29% |
| code-review | 67% | 90% | +23% |
| designing-test-data | 77% | 93% | +16% |
| creating-prompts | 77% | 87% | +10% |

This PR intentionally covers 5 of 20 skills to keep the contribution focused and reviewable — more can be improved in follow-ups or via automated review on future PRs.

<details>
<summary>Changes summary</summary>

**prd-generator** (47% → 90%)
- Rewrote frontmatter description as a quoted string with explicit "Use when" triggers
- Added `argument-hint` and `user-invocable` fields
- Stripped all emoji from headings
- Condensed from ~302 lines to ~133 lines — removed explanatory text, tightened phases, compacted PRD output schema into a numbered reference
- Added operating principles and common failure modes sections
- Preserved all domain expertise (strategy classification, structured discovery, AI/ML requirements, stakeholder alignment)

**tech-debt-analysis (plugin)** (61% → 90%)
- Rewrote description with "Use when" triggers and natural search terms
- Added `argument-hint` and `user-invocable` fields
- Removed emoji from headings, condensed from ~234 to ~138 lines
- Compacted output schema while keeping all 6 report sections
- Added a concrete inline debt item example (TD-042 payment test flakiness)
- Merged self-review and quality rules into tight sections

**code-review** (67% → 90%)
- Replaced generic description with trigger-specific text mentioning PRs, diffs, and merge sign-off
- Added `argument-hint` and `user-invocable` fields
- Removed "Prompt Pattern" section (agent identity anti-pattern)
- Added 4-phase workflow: Scope → Review → Categorize → Verdict
- Added concrete inline example showing a null-check finding with before/after TypeScript

**creating-prompts** (77% → 87%)
- Made description more action-specific with concrete trigger phrases
- Added inline `.prompt.md` example after Phase 3 (complements existing resource files)
- Compacted Phase 2 frontmatter guidance
- Added two new trigger phrases to "When to Use"

**designing-test-data** (77% → 93%)
- Expanded description with granular actions and natural trigger synonyms (mock data, sample data, dummy records)
- Added concrete User Registration data pack example table
- Inlined minimal test data catalog template structure
- Consolidated failure modes into design rules
- Action-verb "When to Use" bullets

</details>

## Want your remaining skills optimised too? 🚀

This PR covers **5 of your 20 skills** to keep the contribution focused and reviewable. We have tooling that can go further:

- **Optimize remaining 15 skills** automatically (same AI-powered pass as above)
- **Add a GitHub Action** — [tesslio/skill-review-and-optimize](https://github.com/tesslio/skill-review-and-optimize) — that automatically reviews (and optionally optimizes) any `SKILL.md` changed in future PRs. Review mode works with zero secrets; maintainers can add `TESSL_API_TOKEN` for AI suggestions and the `/apply-optimize` comment flow.

Interested? Just tick the box below and we'll raise a follow-up PR:

- [ ] **Yes please!** Raise a follow-up PR: optimize the remaining 15 skills + add the Tessl skill-review-and-optimize GitHub Action
- [ ] **No thanks** — happy with the 5 skills in this PR

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
